### PR TITLE
Fixes in metric namespaces and parsing values

### DIFF
--- a/pcm/pcm.go
+++ b/pcm/pcm.go
@@ -38,7 +38,7 @@ const (
 	// Name of plugin
 	name = "pcm"
 	// Version of plugin
-	version = 4
+	version = 5
 	// Type of plugin
 	pluginType = plugin.CollectorPluginType
 )
@@ -133,7 +133,8 @@ func NewPCMCollector() (*PCM, error) {
 				//skip the date and time fields
 				pcm.keys = make([]string, len(keys[2:]))
 				for i, k := range keys[2:] {
-					pcm.keys[i] = fmt.Sprintf("/intel/pcm/%s", k)
+					// removes all spaces from metric key
+					pcm.keys[i] = fmt.Sprintf("/intel/pcm/%s", strings.Replace(k, " ", "", -1))
 				}
 				pcm.mutex.Unlock()
 				continue
@@ -146,7 +147,8 @@ func NewPCMCollector() (*PCM, error) {
 				if err == nil {
 					pcm.data[pcm.keys[i]] = v
 				} else {
-					panic(err)
+					fmt.Fprintln(os.Stderr, "Invalid metric value", err)
+					pcm.data[pcm.keys[i]] = nil
 				}
 			}
 			pcm.mutex.Unlock()


### PR DESCRIPTION
- removed spaces in metric's namespace (for issue https://github.com/intelsdi-x/pulse-plugin-collector-pcm/issues/5)
- do not panic if value parseFloat returns error, but assign nil to value

**Before:**
What was found out during tests with pcm tool in the same version on different machines is, that the command `pcm.x /csv -nc -r 1` output  could contain **N/A** value. This causes that plugin panics.

ERROR:
2015/11/04 13:47:29 2015/11/04 13:47:29 method Token has wrong number of ins: 1
2015/11/04 13:47:30 panic: strconv.ParseFloat: parsing "N/A": invalid syntax

**Now:**
Currently `pulsectl task watch` with pcm metrics looks like below:

![image](https://cloud.githubusercontent.com/assets/11335874/10940692/0ea69930-8308-11e5-8ee1-63b49e0750e6.png)
