### PR TITLE
Removed support for Go 1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-- 1.4.3
 - 1.5.3
 before_install:
 - go get github.com/tools/godep

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order to use this plugin user is required to have PCM installed in system.
 ### System Requirements
 
 * [Intel PCM] (http://www.intel.com/software/pcm)
-* [golang 1.4+](https://golang.org/dl/)
+* [golang 1.5+](https://golang.org/dl/)
 * Root privileges (snapd has to be running with root privileges for ability to collect data from PCM)
  
 **Suggestions**


### PR DESCRIPTION
Removing support for Go 1.4.3 allows to use golint in test script. golint has dropped support for Go 1.4.3 and now requires Go 1.5 or Go 1.6. 