### PR TITLE
Added error handling with failure reason

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,8 @@ import (
 
 // plugin bootstrap
 func main() {
-	p, err := pcm.NewPCMCollector()
-	if err != nil {
-		panic(err)
-	}
+	p := pcm.NewPCMCollector()
+
 	plugin.Start(
 		pcm.Meta(),
 		p,

--- a/pcm/pcm.go
+++ b/pcm/pcm.go
@@ -22,6 +22,8 @@ package pcm
 import (
 	"bufio"
 	"fmt"
+	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,9 +32,7 @@ import (
 	"sync"
 	"time"
 
-	"io"
-
-	"math"
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap-plugin-utilities/ns"
 	"github.com/intelsdi-x/snap/control/plugin"
@@ -44,7 +44,7 @@ const (
 	// Name of plugin
 	name = "pcm"
 	// Version of plugin
-	version = 9
+	version = 10
 	// Type of plugin
 	pluginType = plugin.CollectorPluginType
 )
@@ -55,9 +55,10 @@ func Meta() *plugin.PluginMeta {
 
 // PCM
 type PCM struct {
-	keys  []string
-	data  map[string]float64
-	mutex *sync.RWMutex
+	keys        []string
+	data        map[string]float64
+	mutex       *sync.RWMutex
+	initialized bool
 }
 
 func (p *PCM) Keys() []string {
@@ -70,6 +71,17 @@ func (p *PCM) Data() map[string]float64 {
 
 // // CollectMetrics returns metrics from pcm
 func (p *PCM) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
+	if p.initialized == false {
+		err := p.run()
+		if err != nil {
+			log.WithFields(log.Fields{
+				"block":    "CollectMetrics",
+				"function": "run",
+			}).Error(err)
+			return nil, err
+		}
+		p.initialized = true
+	}
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	for i := range mts {
@@ -85,8 +97,20 @@ func (p *PCM) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, erro
 // GetMetricTypes returns the metric types exposed by pcm
 func (p *PCM) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error) {
 	mts := make([]plugin.MetricType, len(p.keys))
+	if p.initialized == false {
+		err := p.run()
+		if err != nil {
+			log.WithFields(log.Fields{
+				"block":    "GetMetricTypes",
+				"function": "run",
+			}).Error(err)
+			return nil, err
+		}
+		p.initialized = true
+	}
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
+
 	for i, k := range p.keys {
 		mts[i] = plugin.MetricType{Namespace_: core.NewNamespace(strings.Split(strings.TrimPrefix(k, "/"), "/")...)}
 	}
@@ -99,15 +123,8 @@ func (p *PCM) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	return c, nil
 }
 
-func NewPCMCollector() (*PCM, error) {
-	pcm := &PCM{mutex: &sync.RWMutex{}, data: map[string]float64{}}
-
-	err := pcm.run()
-	if err != nil {
-		return nil, err
-	}
-
-	return pcm, nil
+func NewPCMCollector() *PCM {
+	return &PCM{mutex: &sync.RWMutex{}, data: map[string]float64{}, initialized: false}
 }
 func (pcm *PCM) run() error {
 	var cmd *exec.Cmd
@@ -117,7 +134,7 @@ func (pcm *PCM) run() error {
 		c, err := exec.LookPath("pcm.x")
 		if err != nil {
 			fmt.Fprint(os.Stderr, "Unable to find PCM.  Ensure it's in your path or set SNAP_PCM_PATH.")
-			panic(err)
+			return err
 		}
 		cmd = exec.Command(c, "/csv", "-nc", "-r", "1")
 	}


### PR DESCRIPTION
Fixes #33

Summary of changes:
- removed `panic(err)`
- improving plugin load error message
- incremented plugin's version

How to verify it:
- load this plugin when pcm.x is unavailable on your setup

### BEFORE
```
$ snaptel plugin load snap-plugin-collector-pcm 
Error loading plugin:
timed out waiting for plugin snap-plugin-collector-pcm
```

### AFTER
```
$ snaptel plugin load snap-plugin-collector-pcm
Error loading plugin:
GetMetricTypes call error : exec: "pcm.x": executable file not found in $PATH
```

Testing done:
- manually run an exemplary task manifest

