### PR TITLE
Added error handling with failure reason

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,8 @@ import (
 
 // plugin bootstrap
 func main() {
-	p, err := pcm.NewPCMCollector()
-	if err != nil {
-		panic(err)
-	}
+	p := pcm.NewPCMCollector()
+
 	plugin.Start(
 		pcm.Meta(),
 		p,


### PR DESCRIPTION
Fixes #33

Summary of changes:
- removed `panic(err)`
- improving plugin load error message
- incremented plugin's version
- changed [pcm.go, line 99](https://github.com/intelsdi-x/snap-plugin-collector-pcm/compare/master...IzabellaRaulin:removed_panics?expand=1#diff-332970e187e99d74284d1c919c18cd48R99)

How to verify it:
- load this plugin when pcm.x is unavailable on your setup

### BEFORE
```
$ snaptel plugin load snap-plugin-collector-pcm 
Error loading plugin:
timed out waiting for plugin snap-plugin-collector-pcm
```

### AFTER
```
$ snaptel plugin load snap-plugin-collector-pcm
Error loading plugin:
GetMetricTypes call error : exec: "pcm.x": executable file not found in $PATH
```

Testing done:
- manually run an exemplary task manifest

