### PR TITLE
Updated name of plugin author

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,6 @@ There is more than one way to give back, from examples to blogs to code updates.
 
 ## Acknowledgements
 
-* Author: [Izabella Raulin](https://github.com/IzabellaRaulin)
+* Author: [Justin Guidroz](https://github.com/geauxvirtual)
 
 And **thank you!** Your contribution, through code and participation, is incredibly important to us.


### PR DESCRIPTION
Justin is an author of this plugin, not me. My name was put there by mistake during improving  README


A picture of a snapping turtle:
![image](https://cloud.githubusercontent.com/assets/11335874/24702680/26d93892-1a00-11e7-8605-5bed86d24962.png)
